### PR TITLE
Adding missing headers for abs, memcpy and memset.

### DIFF
--- a/rgbcx.h
+++ b/rgbcx.h
@@ -61,6 +61,8 @@
 #include <algorithm>
 #include <assert.h>
 #include <limits.h>
+#include <math.h>
+#include <string.h>
 
 // By default, the table used to accelerate cluster fit on 4 color blocks uses a 969x128 entry table. 
 // To reduce the executable size, set RGBCX_USE_SMALLER_TABLES to 1, which selects the smaller 969x32 entry table. 


### PR DESCRIPTION
Encountered these headers were missing when compiling with clang and gcc.